### PR TITLE
docs: Add documentation comments to Dart package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1
+
+- Add comprehensive dartdoc documentation to all public API elements
+- Document library, classes, methods, and properties following Effective Dart guidelines
+- Improve pub.dev documentation score (target: 20%+ API documentation)
+
 ## 1.0.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A lightweight, pure Dart implementation of BERT WordPiece tokenizer.
 
 ```yaml
 dependencies:
-  dart_bert_tokenizer: ^1.0.0
+  dart_bert_tokenizer: ^1.0.1
 ```
 
 ## Quick Start

--- a/lib/dart_bert_tokenizer.dart
+++ b/lib/dart_bert_tokenizer.dart
@@ -1,3 +1,64 @@
+/// A high-performance BERT WordPiece tokenizer implementation for Dart.
+///
+/// This library provides a complete implementation of the WordPiece tokenization
+/// algorithm used in BERT and other transformer models. It is designed to be
+/// compatible with HuggingFace tokenizers while offering excellent performance
+/// for Dart applications.
+///
+/// ## Features
+///
+/// - Full WordPiece tokenization compatible with HuggingFace tokenizers
+/// - Support for single text and text pair encoding
+/// - Batch processing with optional parallel execution using isolates
+/// - Configurable padding and truncation strategies
+/// - Pre-tokenization with BERT-style normalization
+/// - Efficient trie-based vocabulary lookup
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// import 'package:dart_bert_tokenizer/dart_bert_tokenizer.dart';
+///
+/// void main() async {
+///   // Load tokenizer from vocabulary file
+///   final tokenizer = await WordPieceTokenizer.fromVocabFile('vocab.txt');
+///
+///   // Encode text
+///   final encoding = tokenizer.encode('Hello, world!');
+///   print(encoding.ids);     // Token IDs
+///   print(encoding.tokens);  // Token strings
+///
+///   // Decode back to text
+///   final decoded = tokenizer.decode(encoding.ids);
+///   print(decoded);  // 'hello , world !'
+/// }
+/// ```
+///
+/// ## Text Pair Encoding
+///
+/// For tasks like question answering or sentence similarity:
+///
+/// ```dart
+/// final encoding = tokenizer.encodePair(
+///   'What is Dart?',
+///   'Dart is a programming language.',
+/// );
+/// print(encoding.typeIds);  // Segment IDs (0 for first, 1 for second)
+/// ```
+///
+/// ## Batch Processing
+///
+/// For processing multiple texts efficiently:
+///
+/// ```dart
+/// final encodings = await tokenizer.encodeBatchParallel([
+///   'First sentence.',
+///   'Second sentence.',
+///   'Third sentence.',
+/// ]);
+/// ```
+library dart_bert_tokenizer;
+
 export 'src/encoding.dart' show Encoding, EncodingBuilder, TruncationStrategy;
 export 'src/pre_tokenizer.dart' show BertPreTokenizer, PreToken;
 export 'src/trie.dart' show Trie, TrieNode, TrieMatch;

--- a/lib/src/encoding.dart
+++ b/lib/src/encoding.dart
@@ -1,17 +1,101 @@
 import 'dart:typed_data';
 
-enum TruncationStrategy { longestFirst, onlyFirst, onlySecond, doNotTruncate }
+/// Strategy for truncating text pairs when they exceed the maximum length.
+///
+/// Used with [WordPieceTokenizer.encodePair] and [TruncationConfig] to
+/// control how text pairs are truncated.
+enum TruncationStrategy {
+  /// Removes tokens from the longer sequence first, alternating if equal.
+  ///
+  /// This is the default strategy and typically produces the best results
+  /// for most use cases.
+  longestFirst,
 
+  /// Only truncates the first sequence.
+  ///
+  /// Useful when the second sequence (e.g., context) should be preserved.
+  onlyFirst,
+
+  /// Only truncates the second sequence.
+  ///
+  /// Useful when the first sequence (e.g., question) should be preserved.
+  onlySecond,
+
+  /// Does not truncate; returns the full sequences.
+  ///
+  /// Use with caution as this may produce sequences longer than the model
+  /// can handle.
+  doNotTruncate,
+}
+
+/// The result of tokenizing text with a [WordPieceTokenizer].
+///
+/// Contains all the information needed to feed text into a BERT model:
+/// token IDs, attention masks, type IDs (for distinguishing text pairs),
+/// and mappings between tokens and original text positions.
+///
+/// ## Properties
+///
+/// - [ids]: Token IDs for model input
+/// - [tokens]: Token strings for debugging
+/// - [attentionMask]: 1 for real tokens, 0 for padding
+/// - [typeIds]: Segment IDs (0 for first sequence, 1 for second)
+/// - [specialTokensMask]: 1 for special tokens, 0 for regular tokens
+///
+/// ## Token-Character Mapping
+///
+/// The encoding provides methods to map between tokens and characters:
+///
+/// ```dart
+/// // Find which token contains character at position 5
+/// final tokenIdx = encoding.charToToken(5);
+///
+/// // Find character span for token at index 2
+/// final (start, end) = encoding.tokenToChars(2)!;
+/// ```
 class Encoding {
+  /// The token strings in this encoding.
   final List<String> tokens;
+
+  /// The token IDs for model input.
+  ///
+  /// These are the integer indices into the vocabulary that the model uses.
   final Int32List ids;
+
+  /// Segment/type IDs distinguishing text pairs.
+  ///
+  /// For single text: all 0s.
+  /// For text pairs: 0 for first sequence, 1 for second sequence.
   final Uint8List typeIds;
+
+  /// Attention mask indicating which tokens are real vs padding.
+  ///
+  /// 1 for real tokens, 0 for padding tokens.
   final Uint8List attentionMask;
+
+  /// Mask indicating which tokens are special tokens.
+  ///
+  /// 1 for special tokens (`[CLS]`, `[SEP]`, `[PAD]`), 0 for regular tokens.
   final Uint8List specialTokensMask;
+
+  /// Character offsets for each token as `(start, end)` pairs.
+  ///
+  /// Maps each token back to its position in the original text.
+  /// Special tokens have offset `(0, 0)`.
   final List<(int, int)> offsets;
+
+  /// Word indices for each token.
+  ///
+  /// Multiple tokens from the same word share the same word ID.
+  /// Special tokens have `null` word ID.
   final List<int?> wordIds;
+
   final List<int?>? _sequenceIds;
 
+  /// Creates an encoding with the specified data.
+  ///
+  /// This constructor is typically not called directly; use
+  /// [WordPieceTokenizer.encode] or [EncodingBuilder] instead.
   Encoding({
     required this.tokens,
     required List<int> ids,
@@ -42,12 +126,19 @@ class Encoding {
     List<int?>? sequenceIds,
   }) : _sequenceIds = sequenceIds;
 
+  /// The number of tokens in this encoding.
   int get length => tokens.length;
 
+  /// Whether this encoding contains no tokens.
   bool get isEmpty => tokens.isEmpty;
 
+  /// Whether this encoding contains at least one token.
   bool get isNotEmpty => tokens.isNotEmpty;
 
+  /// Sequence IDs indicating which sequence each token belongs to.
+  ///
+  /// Returns 0 for first sequence tokens, 1 for second sequence tokens,
+  /// and `null` for special tokens.
   List<int?> get sequenceIds {
     if (_sequenceIds != null) return _sequenceIds;
 
@@ -57,6 +148,9 @@ class Encoding {
     });
   }
 
+  /// Returns the number of sequences in this encoding.
+  ///
+  /// Returns 0 if empty, 1 for single text, 2 for text pairs.
   int get nSequences {
     final seqIds = sequenceIds;
     if (seqIds.any((id) => id == 1)) return 2;
@@ -64,6 +158,12 @@ class Encoding {
     return 0;
   }
 
+  /// Finds the token index containing the given character position.
+  ///
+  /// - [charPos]: Character position in the original text.
+  /// - [sequenceIndex]: Which sequence to search (0 or 1 for pairs).
+  ///
+  /// Returns the token index, or `null` if no token contains this position.
   int? charToToken(int charPos, {int sequenceIndex = 0}) {
     final seqIds = sequenceIds;
     for (var i = 0; i < length; i++) {
@@ -76,12 +176,19 @@ class Encoding {
     return null;
   }
 
+  /// Finds the word index containing the given character position.
+  ///
+  /// - [charPos]: Character position in the original text.
+  /// - [sequenceIndex]: Which sequence to search (0 or 1 for pairs).
   int? charToWord(int charPos, {int sequenceIndex = 0}) {
     final tokenIdx = charToToken(charPos, sequenceIndex: sequenceIndex);
     if (tokenIdx == null) return null;
     return wordIds[tokenIdx];
   }
 
+  /// Returns the character span for a token at the given index.
+  ///
+  /// Returns `(start, end)` character positions, or `null` for special tokens.
   (int, int)? tokenToChars(int tokenIndex) {
     if (tokenIndex < 0 || tokenIndex >= length) return null;
     final offset = offsets[tokenIndex];
@@ -89,16 +196,22 @@ class Encoding {
     return offset;
   }
 
+  /// Returns the word index for a token at the given index.
   int? tokenToWord(int tokenIndex) {
     if (tokenIndex < 0 || tokenIndex >= length) return null;
     return wordIds[tokenIndex];
   }
 
+  /// Returns which sequence a token belongs to (0, 1, or null for special).
   int? tokenToSequence(int tokenIndex) {
     if (tokenIndex < 0 || tokenIndex >= length) return null;
     return sequenceIds[tokenIndex];
   }
 
+  /// Returns the character span for an entire word.
+  ///
+  /// - [wordIndex]: The word index to look up.
+  /// - [sequenceIndex]: Which sequence to search.
   (int, int)? wordToChars(int wordIndex, {int sequenceIndex = 0}) {
     final seqIds = sequenceIds;
     int? start;
@@ -117,6 +230,9 @@ class Encoding {
     return (start, end);
   }
 
+  /// Returns the token span for an entire word.
+  ///
+  /// Returns `(startTokenIdx, endTokenIdx)` where end is exclusive.
   (int, int)? wordToTokens(int wordIndex, {int sequenceIndex = 0}) {
     final seqIds = sequenceIds;
     int? start;
@@ -134,6 +250,7 @@ class Encoding {
     return (start, end);
   }
 
+  /// Creates an empty encoding with no tokens.
   factory Encoding.empty() => Encoding._typed(
     tokens: const [],
     ids: Int32List(0),
@@ -145,6 +262,10 @@ class Encoding {
     sequenceIds: const [],
   );
 
+  /// Merges multiple encodings into a single encoding.
+  ///
+  /// - [encodings]: List of encodings to merge.
+  /// - [growingOffsets]: If true, offsets accumulate across encodings.
   static Encoding merge(
     List<Encoding> encodings, {
     bool growingOffsets = true,
@@ -232,6 +353,14 @@ class Encoding {
     );
   }
 
+  /// Returns a new encoding padded to the target length.
+  ///
+  /// - [targetLength]: The desired total length.
+  /// - [padTokenId]: The token ID to use for padding.
+  /// - [padToken]: The token string for padding (default: `[PAD]`).
+  /// - [padOnRight]: Whether to pad on the right side (default: true).
+  ///
+  /// Returns `this` if already at or above target length.
   Encoding withPadding({
     required int targetLength,
     required int padTokenId,
@@ -291,6 +420,10 @@ class Encoding {
     );
   }
 
+  /// Returns a new encoding padded to a multiple of the given value.
+  ///
+  /// Useful for hardware optimization where tensor dimensions should be
+  /// multiples of certain values.
   Encoding withPaddingToMultipleOf({
     required int multiple,
     required int padTokenId,
@@ -311,6 +444,13 @@ class Encoding {
     );
   }
 
+  /// Returns a new encoding truncated to the maximum length.
+  ///
+  /// - [maxLength]: The maximum number of tokens.
+  /// - [truncateFromEnd]: If true, removes tokens from the end; otherwise
+  ///   removes from the beginning.
+  ///
+  /// Returns `this` if already at or below max length.
   Encoding withTruncation({
     required int maxLength,
     bool truncateFromEnd = true,
@@ -347,6 +487,9 @@ class Encoding {
     }
   }
 
+  /// Converts this encoding to a Map representation.
+  ///
+  /// Useful for serialization or debugging.
   Map<String, dynamic> toMap() => {
     'tokens': tokens,
     'ids': ids,
@@ -362,6 +505,15 @@ class Encoding {
   String toString() =>
       'Encoding(tokens: $tokens, ids: $ids, nSequences: $nSequences)';
 
+  /// Truncates a pair of encodings to fit within the maximum length.
+  ///
+  /// Returns a tuple of truncated encodings based on the specified strategy.
+  ///
+  /// - [encodingA]: The first encoding.
+  /// - [encodingB]: The second encoding.
+  /// - [maxLength]: Maximum combined length including special tokens.
+  /// - [strategy]: How to distribute truncation between sequences.
+  /// - [numSpecialTokens]: Number of special tokens that will be added.
   static (Encoding, Encoding) truncatePair({
     required Encoding encodingA,
     required Encoding encodingB,
@@ -431,6 +583,18 @@ class Encoding {
   }
 }
 
+/// A builder for constructing [Encoding] objects incrementally.
+///
+/// Useful for building encodings token by token during the tokenization
+/// process.
+///
+/// Example:
+/// ```dart
+/// final builder = EncodingBuilder();
+/// builder.addSpecialToken(token: '[CLS]', id: 101, typeId: 0);
+/// builder.addToken(token: 'hello', id: 7592, typeId: 0, offset: (0, 5));
+/// final encoding = builder.build();
+/// ```
 class EncodingBuilder {
   final List<String> _tokens = [];
   final List<int> _ids = [];
@@ -441,6 +605,14 @@ class EncodingBuilder {
   final List<int?> _wordIds = [];
   final List<int?> _sequenceIds = [];
 
+  /// Adds a regular token to the encoding.
+  ///
+  /// - [token]: The token string.
+  /// - [id]: The token's vocabulary ID.
+  /// - [typeId]: Segment ID (0 or 1).
+  /// - [offset]: Character span in original text as `(start, end)`.
+  /// - [wordId]: Optional word index.
+  /// - [sequenceId]: Optional sequence ID.
   void addToken({
     required String token,
     required int id,
@@ -459,6 +631,9 @@ class EncodingBuilder {
     _sequenceIds.add(sequenceId ?? typeId);
   }
 
+  /// Adds a special token (e.g., `[CLS]`, `[SEP]`, `[PAD]`) to the encoding.
+  ///
+  /// Special tokens have no character offset and null word/sequence IDs.
   void addSpecialToken({
     required String token,
     required int id,
@@ -474,6 +649,9 @@ class EncodingBuilder {
     _sequenceIds.add(null);
   }
 
+  /// Builds and returns the constructed [Encoding].
+  ///
+  /// The builder can be reused after calling [clear].
   Encoding build() => Encoding._typed(
     tokens: List.unmodifiable(_tokens),
     ids: Int32List.fromList(_ids),
@@ -485,6 +663,7 @@ class EncodingBuilder {
     sequenceIds: List.unmodifiable(_sequenceIds),
   );
 
+  /// Clears the builder for reuse.
   void clear() {
     _tokens.clear();
     _ids.clear();

--- a/lib/src/pre_tokenizer.dart
+++ b/lib/src/pre_tokenizer.dart
@@ -1,25 +1,60 @@
+/// A pre-tokenized word with its position in the original text.
+///
+/// Pre-tokens are the result of splitting text on whitespace and punctuation
+/// before WordPiece tokenization.
 class PreToken {
+  /// The text content of this pre-token.
   final String text;
+
+  /// The starting character position in the original text.
   final int start;
+
+  /// The ending character position in the original text (exclusive).
   final int end;
 
+  /// Creates a pre-token with the given text and positions.
   const PreToken({required this.text, required this.start, required this.end});
 
   @override
   String toString() => 'PreToken("$text", [$start:$end])';
 }
 
+/// BERT-style pre-tokenizer for text normalization and splitting.
+///
+/// Performs the following operations:
+/// - Normalizes Unicode characters and removes control characters
+/// - Optionally converts text to lowercase
+/// - Optionally strips accents (e.g., `é` -> `e`)
+/// - Adds spaces around Chinese characters for character-level tokenization
+/// - Splits on whitespace and punctuation
+///
+/// Example:
+/// ```dart
+/// final preTokenizer = BertPreTokenizer();
+/// final tokens = preTokenizer.preTokenize('Hello, World!');
+/// // Returns: [PreToken("hello", 0, 5), PreToken(",", 5, 6), ...]
+/// ```
 class BertPreTokenizer {
+  /// Whether to convert text to lowercase.
   final bool lowercase;
+
+  /// Whether to strip accents from characters.
   final bool stripAccents;
+
+  /// Whether to add spaces around Chinese characters.
   final bool handleChineseChars;
 
+  /// Creates a BERT pre-tokenizer with the specified options.
   const BertPreTokenizer({
     this.lowercase = true,
     this.stripAccents = true,
     this.handleChineseChars = true,
   });
 
+  /// Pre-tokenizes text into a list of [PreToken]s.
+  ///
+  /// Normalizes the text and splits it on whitespace and punctuation,
+  /// preserving character positions for later mapping.
   List<PreToken> preTokenize(String text) {
     final normalized = _normalizeSinglePass(text);
     return _splitOnWhitespaceAndPunctuation(normalized);

--- a/lib/src/trie.dart
+++ b/lib/src/trie.dart
@@ -1,16 +1,46 @@
+/// A node in a [Trie] data structure.
+///
+/// Each node represents a character in the trie and can optionally mark
+/// the end of a token.
 class TrieNode {
+  /// Child nodes keyed by Unicode code point.
   final Map<int, TrieNode> children = {};
+
+  /// The token ID if this node marks the end of a token, or `null`.
   int? tokenId;
+
+  /// The token string if this node marks the end of a token, or `null`.
   String? token;
+
+  /// Whether this node marks the end of a valid token.
   bool get isEndOfToken => tokenId != null;
 }
 
+/// A trie (prefix tree) data structure for efficient token lookup.
+///
+/// Used internally by [Vocabulary] for fast longest-prefix matching during
+/// tokenization. Supports Unicode characters through code point indexing.
+///
+/// Example:
+/// ```dart
+/// final trie = Trie();
+/// trie.insert('hello', 1);
+/// trie.insert('help', 2);
+///
+/// final match = trie.findLongestPrefix('hello world');
+/// print(match?.token); // 'hello'
+/// ```
 class Trie {
   final TrieNode _root = TrieNode();
   int _size = 0;
 
+  /// The number of tokens in this trie.
   int get size => _size;
 
+  /// Inserts a token into the trie.
+  ///
+  /// - [token]: The token string to insert.
+  /// - [tokenId]: The ID to associate with this token.
   void insert(String token, int tokenId) {
     var node = _root;
 
@@ -25,6 +55,7 @@ class Trie {
     node.token = token;
   }
 
+  /// Looks up a token and returns its ID, or `null` if not found.
   int? lookup(String token) {
     var node = _root;
 
@@ -39,8 +70,15 @@ class Trie {
     return node.tokenId;
   }
 
+  /// Returns whether the trie contains the given token.
   bool contains(String token) => lookup(token) != null;
 
+  /// Finds the longest matching token starting at the given position.
+  ///
+  /// - [text]: The text to search in.
+  /// - [startIndex]: Position to start matching from (default: 0).
+  ///
+  /// Returns a [TrieMatch] with the longest match, or `null` if no match.
   TrieMatch? findLongestPrefix(String text, [int startIndex = 0]) {
     var node = _root;
     TrieMatch? lastMatch;
@@ -81,6 +119,9 @@ class Trie {
     return lastMatch;
   }
 
+  /// Finds all matching tokens starting at the given position.
+  ///
+  /// Returns matches in order of increasing length.
   List<TrieMatch> findAllPrefixes(String text, [int startIndex = 0]) {
     final matches = <TrieMatch>[];
     var node = _root;
@@ -123,18 +164,31 @@ class Trie {
     return matches;
   }
 
+  /// Removes all tokens from this trie.
   void clear() {
     _root.children.clear();
     _size = 0;
   }
 }
 
+/// Represents a successful token match from a [Trie] lookup.
+///
+/// Contains the matched token, its ID, and the character range in the
+/// source text.
 class TrieMatch {
+  /// The matched token string.
   final String token;
+
+  /// The vocabulary ID of the matched token.
   final int tokenId;
+
+  /// The starting character position of the match.
   final int start;
+
+  /// The ending character position of the match (exclusive).
   final int end;
 
+  /// Creates a trie match result.
   const TrieMatch({
     required this.token,
     required this.tokenId,
@@ -142,6 +196,7 @@ class TrieMatch {
     required this.end,
   });
 
+  /// The length of the match in characters.
   int get length => end - start;
 
   @override

--- a/lib/src/vocabulary.dart
+++ b/lib/src/vocabulary.dart
@@ -2,40 +2,94 @@ import 'dart:io';
 
 import 'trie.dart';
 
+/// Constants for BERT special tokens.
+///
+/// These tokens have special meaning in BERT models:
+/// - `[PAD]`: Padding token for batch processing
+/// - `[UNK]`: Unknown token for out-of-vocabulary words
+/// - `[CLS]`: Classification token at the start of each sequence
+/// - `[SEP]`: Separator token between sequences
+/// - `[MASK]`: Mask token for masked language modeling
 class SpecialTokens {
+  /// Padding token used to pad sequences to equal length.
   static const String pad = '[PAD]';
+
+  /// Unknown token used for out-of-vocabulary words.
   static const String unk = '[UNK]';
+
+  /// Classification token added at the start of each sequence.
   static const String cls = '[CLS]';
+
+  /// Separator token used between text pairs.
   static const String sep = '[SEP]';
+
+  /// Mask token used in masked language modeling tasks.
   static const String mask = '[MASK]';
+
+  /// List of all default special tokens.
   static const List<String> defaults = [pad, unk, cls, sep, mask];
 }
 
+/// A vocabulary mapping between tokens and their integer IDs.
+///
+/// The vocabulary is loaded from a file where each line contains a token,
+/// with the line number (0-indexed) being the token's ID.
+///
+/// Internally uses trie data structures for efficient longest-prefix matching
+/// during tokenization.
+///
+/// ## Loading a Vocabulary
+///
+/// ```dart
+/// // From file (async)
+/// final vocab = await Vocabulary.fromFile('vocab.txt');
+///
+/// // From file (sync)
+/// final vocab = Vocabulary.fromFileSync('vocab.txt');
+///
+/// // From string content
+/// final vocab = Vocabulary.fromString(vocabContent);
+/// ```
 class Vocabulary {
   final Map<String, int> _tokenToId = {};
   final List<String> _idToToken = [];
   final Trie _trie = Trie();
   final Trie _subwordTrie = Trie();
+
+  /// The prefix used for subword tokens (default: `##`).
   final String subwordPrefix;
 
+  /// Creates an empty vocabulary with the given subword prefix.
   Vocabulary({this.subwordPrefix = '##'});
 
+  /// The number of tokens in this vocabulary.
   int get size => _idToToken.length;
 
+  /// Trie for looking up whole-word tokens.
   Trie get trie => _trie;
 
+  /// Trie for looking up subword tokens (without prefix).
   Trie get subwordTrie => _subwordTrie;
 
+  /// The ID of the unknown token `[UNK]`.
   int get unkTokenId => _tokenToId[SpecialTokens.unk] ?? 100;
 
+  /// The ID of the classification token `[CLS]`.
   int get clsTokenId => _tokenToId[SpecialTokens.cls] ?? 101;
 
+  /// The ID of the separator token `[SEP]`.
   int get sepTokenId => _tokenToId[SpecialTokens.sep] ?? 102;
 
+  /// The ID of the padding token `[PAD]`.
   int get padTokenId => _tokenToId[SpecialTokens.pad] ?? 0;
 
+  /// The ID of the mask token `[MASK]`.
   int get maskTokenId => _tokenToId[SpecialTokens.mask] ?? 103;
 
+  /// Loads a vocabulary from a file asynchronously.
+  ///
+  /// The file should contain one token per line, with the line number
+  /// (0-indexed) being the token's ID.
   static Future<Vocabulary> fromFile(
     String path, {
     String subwordPrefix = '##',
@@ -45,17 +99,20 @@ class Vocabulary {
     return Vocabulary._fromLines(lines, subwordPrefix: subwordPrefix);
   }
 
+  /// Loads a vocabulary from a file synchronously.
   static Vocabulary fromFileSync(String path, {String subwordPrefix = '##'}) {
     final file = File(path);
     final lines = file.readAsLinesSync();
     return Vocabulary._fromLines(lines, subwordPrefix: subwordPrefix);
   }
 
+  /// Creates a vocabulary from a string containing tokens separated by newlines.
   static Vocabulary fromString(String content, {String subwordPrefix = '##'}) {
     final lines = content.split('\n');
     return Vocabulary._fromLines(lines, subwordPrefix: subwordPrefix);
   }
 
+  /// Creates a vocabulary from a list of token strings.
   static Vocabulary fromTokens(
     List<String> tokens, {
     String subwordPrefix = '##',
@@ -95,10 +152,16 @@ class Vocabulary {
     }
   }
 
+  /// Converts a token string to its ID.
+  ///
+  /// Returns the unknown token ID if the token is not in the vocabulary.
   int tokenToId(String token) {
     return _tokenToId[token] ?? unkTokenId;
   }
 
+  /// Converts a token ID to its string representation.
+  ///
+  /// Returns `[UNK]` if the ID is out of range.
   String idToToken(int id) {
     if (id < 0 || id >= _idToToken.length) {
       return SpecialTokens.unk;
@@ -107,16 +170,27 @@ class Vocabulary {
     return token.isEmpty ? SpecialTokens.unk : token;
   }
 
+  /// Returns whether the vocabulary contains the given token.
   bool contains(String token) => _tokenToId.containsKey(token);
 
+  /// Returns whether the token is a special token (e.g., `[CLS]`, `[SEP]`).
   bool isSpecialToken(String token) {
     return token.startsWith('[') && token.endsWith(']');
   }
 
+  /// Returns an unmodifiable view of the token-to-ID mapping.
   Map<String, int> get vocabularyMap => Map.unmodifiable(_tokenToId);
 
+  /// Returns an unmodifiable list of all tokens in ID order.
   List<String> get tokens => List.unmodifiable(_idToToken);
 
+  /// Finds the longest matching token starting at the given position.
+  ///
+  /// - [text]: The text to search in.
+  /// - [startIndex]: Position to start matching from.
+  /// - [isSubword]: If true, searches the subword trie instead.
+  ///
+  /// Returns the match, or `null` if no match is found.
   TrieMatch? findLongestMatch(
     String text, {
     int startIndex = 0,

--- a/lib/src/wordpiece_tokenizer.dart
+++ b/lib/src/wordpiece_tokenizer.dart
@@ -7,13 +7,54 @@ import 'vocabulary.dart';
 
 const _kMinBatchSizeForParallel = 8;
 
-enum PaddingDirection { right, left }
+/// Specifies the direction for padding tokens.
+///
+/// Used with [PaddingConfig] to control where padding tokens are added.
+enum PaddingDirection {
+  /// Adds padding tokens to the right (end) of the sequence.
+  right,
 
+  /// Adds padding tokens to the left (beginning) of the sequence.
+  left,
+}
+
+/// Configuration for sequence padding.
+///
+/// Controls how sequences are padded to achieve uniform length in batch
+/// processing. Padding can be applied to a fixed length or to a multiple
+/// of a specified value.
+///
+/// Example:
+/// ```dart
+/// // Pad all sequences to length 128
+/// tokenizer.enablePadding(length: 128);
+///
+/// // Pad to the nearest multiple of 8
+/// tokenizer.enablePadding(padToMultipleOf: 8);
+/// ```
 class PaddingConfig {
+  /// The direction in which padding tokens are added.
+  ///
+  /// Defaults to [PaddingDirection.right].
   final PaddingDirection direction;
+
+  /// The target length to pad sequences to.
+  ///
+  /// If `null`, sequences are padded to the length of the longest sequence
+  /// in the batch.
   final int? length;
+
+  /// Pads sequences to a multiple of this value.
+  ///
+  /// Useful for hardware optimization where tensor dimensions should be
+  /// multiples of certain values (e.g., 8 or 16).
   final int? padToMultipleOf;
 
+  /// Creates a padding configuration.
+  ///
+  /// - [direction]: Where to add padding tokens (default: right).
+  /// - [length]: Fixed target length, or `null` for dynamic padding.
+  /// - [padToMultipleOf]: Pad to nearest multiple of this value.
   const PaddingConfig({
     this.direction = PaddingDirection.right,
     this.length,
@@ -21,13 +62,57 @@ class PaddingConfig {
   });
 }
 
-enum TruncationDirection { right, left }
+/// Specifies the direction for sequence truncation.
+///
+/// Used with [TruncationConfig] to control which end of the sequence is
+/// truncated when it exceeds the maximum length.
+enum TruncationDirection {
+  /// Truncates tokens from the right (end) of the sequence.
+  right,
 
+  /// Truncates tokens from the left (beginning) of the sequence.
+  left,
+}
+
+/// Configuration for sequence truncation.
+///
+/// Controls how sequences are truncated when they exceed a maximum length.
+/// This is essential for BERT models which have a fixed maximum sequence
+/// length (typically 512 tokens).
+///
+/// Example:
+/// ```dart
+/// // Truncate sequences longer than 512 tokens
+/// tokenizer.enableTruncation(maxLength: 512);
+///
+/// // Truncate from the left for tasks where the end is more important
+/// tokenizer.enableTruncation(
+///   maxLength: 128,
+///   direction: TruncationDirection.left,
+/// );
+/// ```
 class TruncationConfig {
+  /// The maximum length of the encoded sequence.
+  ///
+  /// Sequences longer than this will be truncated.
   final int maxLength;
+
+  /// The direction from which to truncate.
+  ///
+  /// Defaults to [TruncationDirection.right] (truncate from end).
   final TruncationDirection direction;
+
+  /// The strategy for truncating text pairs.
+  ///
+  /// Only applicable when encoding text pairs. See [TruncationStrategy]
+  /// for available options.
   final TruncationStrategy strategy;
 
+  /// Creates a truncation configuration.
+  ///
+  /// - [maxLength]: Required. The maximum sequence length.
+  /// - [direction]: Where to truncate from (default: right).
+  /// - [strategy]: How to truncate text pairs (default: longest first).
   const TruncationConfig({
     required this.maxLength,
     this.direction = TruncationDirection.right,
@@ -35,15 +120,66 @@ class TruncationConfig {
   });
 }
 
+/// Configuration options for the WordPiece tokenizer.
+///
+/// Controls the behavior of text normalization, special token handling,
+/// and subword tokenization.
+///
+/// The default configuration matches the standard BERT uncased tokenizer:
+/// - Lowercase text
+/// - Strip accents
+/// - Add special handling for Chinese characters
+/// - Use `##` as the subword prefix
+/// - Add `[CLS]` and `[SEP]` tokens automatically
+///
+/// Example:
+/// ```dart
+/// // Standard uncased configuration (default)
+/// final uncasedConfig = WordPieceConfig();
+///
+/// // Cased configuration (preserves case)
+/// final casedConfig = WordPieceConfig(
+///   lowercase: false,
+///   stripAccents: false,
+/// );
+/// ```
 class WordPieceConfig {
+  /// Whether to convert text to lowercase during normalization.
+  ///
+  /// Set to `false` for cased models like `bert-base-cased`.
   final bool lowercase;
+
+  /// Whether to remove accents from characters during normalization.
+  ///
+  /// For example, `é` becomes `e`.
   final bool stripAccents;
+
+  /// Whether to add spaces around Chinese characters.
+  ///
+  /// This ensures each Chinese character is treated as a separate token,
+  /// which is the standard behavior for BERT models.
   final bool handleChineseChars;
+
+  /// The prefix added to subword tokens (continuation tokens).
+  ///
+  /// Standard BERT uses `##` (e.g., "playing" -> ["play", "##ing"]).
   final String subwordPrefix;
+
+  /// Maximum length of a word before it's replaced with `[UNK]`.
+  ///
+  /// Words longer than this are considered out-of-vocabulary.
   final int maxWordLength;
+
+  /// Whether to automatically add `[CLS]` token at the start of encodings.
   final bool addClsToken;
+
+  /// Whether to automatically add `[SEP]` token at the end of encodings.
   final bool addSepToken;
 
+  /// Creates a WordPiece tokenizer configuration.
+  ///
+  /// All parameters have sensible defaults matching the standard BERT
+  /// uncased tokenizer.
   const WordPieceConfig({
     this.lowercase = true,
     this.stripAccents = true,
@@ -55,13 +191,64 @@ class WordPieceConfig {
   });
 }
 
+/// A WordPiece tokenizer compatible with BERT and HuggingFace tokenizers.
+///
+/// This tokenizer implements the WordPiece algorithm used in BERT models.
+/// It provides methods for encoding text to token IDs and decoding IDs back
+/// to text, with support for single texts, text pairs, and batch processing.
+///
+/// ## Creating a Tokenizer
+///
+/// ```dart
+/// // From a vocabulary file (async)
+/// final tokenizer = await WordPieceTokenizer.fromVocabFile('vocab.txt');
+///
+/// // From a vocabulary file (sync)
+/// final tokenizer = WordPieceTokenizer.fromVocabFileSync('vocab.txt');
+///
+/// // From a Vocabulary object
+/// final tokenizer = WordPieceTokenizer(vocab: vocabulary);
+/// ```
+///
+/// ## Encoding Text
+///
+/// ```dart
+/// // Single text
+/// final encoding = tokenizer.encode('Hello, world!');
+///
+/// // Text pair (for question answering, etc.)
+/// final encoding = tokenizer.encodePair('What is AI?', 'AI is...');
+///
+/// // Batch encoding
+/// final encodings = tokenizer.encodeBatch(['Text 1', 'Text 2']);
+/// ```
+///
+/// ## Padding and Truncation
+///
+/// ```dart
+/// tokenizer
+///   .enablePadding(length: 128)
+///   .enableTruncation(maxLength: 128);
+/// ```
+///
+/// See also:
+/// - [Encoding] for the result of tokenization
+/// - [WordPieceConfig] for tokenizer configuration options
 class WordPieceTokenizer {
+  /// The vocabulary used for token lookup.
   final Vocabulary vocab;
+
+  /// The configuration for this tokenizer.
   final WordPieceConfig config;
+
   late final BertPreTokenizer _preTokenizer;
   PaddingConfig? _paddingConfig;
   TruncationConfig? _truncationConfig;
 
+  /// Creates a WordPiece tokenizer with the given vocabulary.
+  ///
+  /// - [vocab]: The vocabulary containing token-to-ID mappings.
+  /// - [config]: Optional configuration (defaults to standard BERT uncased).
   WordPieceTokenizer({
     required this.vocab,
     this.config = const WordPieceConfig(),
@@ -73,10 +260,24 @@ class WordPieceTokenizer {
     );
   }
 
+  /// Returns the current padding configuration, or `null` if disabled.
   PaddingConfig? get padding => _paddingConfig;
 
+  /// Returns the current truncation configuration, or `null` if disabled.
   TruncationConfig? get truncation => _truncationConfig;
 
+  /// Enables padding for encoded sequences.
+  ///
+  /// Returns `this` for method chaining.
+  ///
+  /// - [direction]: Where to add padding (default: right).
+  /// - [length]: Fixed target length, or `null` to pad to longest in batch.
+  /// - [padToMultipleOf]: Pad to nearest multiple of this value.
+  ///
+  /// Example:
+  /// ```dart
+  /// tokenizer.enablePadding(length: 128, direction: PaddingDirection.right);
+  /// ```
   WordPieceTokenizer enablePadding({
     PaddingDirection direction = PaddingDirection.right,
     int? length,
@@ -90,11 +291,26 @@ class WordPieceTokenizer {
     return this;
   }
 
+  /// Disables padding.
+  ///
+  /// Returns `this` for method chaining.
   WordPieceTokenizer noPadding() {
     _paddingConfig = null;
     return this;
   }
 
+  /// Enables truncation for encoded sequences.
+  ///
+  /// Returns `this` for method chaining.
+  ///
+  /// - [maxLength]: Required. Maximum sequence length (including special tokens).
+  /// - [direction]: Where to truncate from (default: right).
+  /// - [strategy]: How to truncate text pairs (default: longest first).
+  ///
+  /// Example:
+  /// ```dart
+  /// tokenizer.enableTruncation(maxLength: 512);
+  /// ```
   WordPieceTokenizer enableTruncation({
     required int maxLength,
     TruncationDirection direction = TruncationDirection.right,
@@ -108,6 +324,9 @@ class WordPieceTokenizer {
     return this;
   }
 
+  /// Disables truncation.
+  ///
+  /// Returns `this` for method chaining.
   WordPieceTokenizer noTruncation() {
     _truncationConfig = null;
     return this;
@@ -197,6 +416,21 @@ class WordPieceTokenizer {
     return results;
   }
 
+  /// Creates a tokenizer from a vocabulary file asynchronously.
+  ///
+  /// The vocabulary file should contain one token per line, with the line
+  /// number (0-indexed) being the token's ID.
+  ///
+  /// - [path]: Path to the vocabulary file.
+  /// - [config]: Optional tokenizer configuration.
+  ///
+  /// Example:
+  /// ```dart
+  /// final tokenizer = await WordPieceTokenizer.fromVocabFile(
+  ///   'assets/vocab.txt',
+  ///   config: WordPieceConfig(lowercase: false),
+  /// );
+  /// ```
   static Future<WordPieceTokenizer> fromVocabFile(
     String path, {
     WordPieceConfig config = const WordPieceConfig(),
@@ -208,6 +442,9 @@ class WordPieceTokenizer {
     return WordPieceTokenizer(vocab: vocab, config: config);
   }
 
+  /// Creates a tokenizer from a vocabulary file synchronously.
+  ///
+  /// See [fromVocabFile] for details.
   static WordPieceTokenizer fromVocabFileSync(
     String path, {
     WordPieceConfig config = const WordPieceConfig(),
@@ -219,6 +456,9 @@ class WordPieceTokenizer {
     return WordPieceTokenizer(vocab: vocab, config: config);
   }
 
+  /// Returns the number of special tokens that will be added during encoding.
+  ///
+  /// - [isPair]: Whether encoding a text pair (adds extra `[SEP]` token).
   int numSpecialTokensToAdd({bool isPair = false}) {
     var count = 0;
     if (config.addClsToken) count++;
@@ -227,6 +467,23 @@ class WordPieceTokenizer {
     return count;
   }
 
+  /// Encodes a single text string into an [Encoding].
+  ///
+  /// The text is normalized, tokenized using WordPiece, and special tokens
+  /// are added based on the configuration.
+  ///
+  /// - [text]: The text to encode.
+  /// - [addSpecialTokens]: Override whether to add `[CLS]`/`[SEP]` tokens.
+  ///
+  /// Returns an [Encoding] containing token IDs, attention mask, and other
+  /// information needed for model input.
+  ///
+  /// Example:
+  /// ```dart
+  /// final encoding = tokenizer.encode('Hello, world!');
+  /// print(encoding.tokens); // ['[CLS]', 'hello', ',', 'world', '!', '[SEP]']
+  /// print(encoding.ids);    // [101, 7592, 1010, 2088, 999, 102]
+  /// ```
   Encoding encode(String text, {bool? addSpecialTokens}) {
     final shouldAddCls = addSpecialTokens ?? config.addClsToken;
     final shouldAddSep = addSpecialTokens ?? config.addSepToken;
@@ -272,6 +529,27 @@ class WordPieceTokenizer {
     return _applyPostProcessing(builder.build());
   }
 
+  /// Encodes a pair of text strings into a single [Encoding].
+  ///
+  /// Used for tasks like question answering, sentence similarity, or
+  /// natural language inference where two text sequences are needed.
+  ///
+  /// The output format is: `[CLS] textA [SEP] textB [SEP]`
+  ///
+  /// - [textA]: The first text (e.g., question, premise).
+  /// - [textB]: The second text (e.g., context, hypothesis).
+  /// - [addSpecialTokens]: Override whether to add special tokens.
+  /// - [maxLength]: Maximum total length (overrides [enableTruncation]).
+  /// - [truncationStrategy]: How to truncate if sequences are too long.
+  ///
+  /// Example:
+  /// ```dart
+  /// final encoding = tokenizer.encodePair(
+  ///   'What is the capital of France?',
+  ///   'Paris is the capital of France.',
+  /// );
+  /// print(encoding.typeIds); // [0, 0, ..., 0, 1, 1, ..., 1]
+  /// ```
   Encoding encodePair(
     String textA,
     String textB, {
@@ -370,6 +648,16 @@ class WordPieceTokenizer {
     return result;
   }
 
+  /// Encodes multiple texts in a batch.
+  ///
+  /// This method applies consistent padding across all encodings in the batch.
+  /// When padding is enabled, all sequences are padded to the same length.
+  ///
+  /// - [texts]: List of texts to encode.
+  /// - [addSpecialTokens]: Override whether to add special tokens.
+  ///
+  /// Returns a list of [Encoding] objects with consistent lengths (if padding
+  /// is enabled).
   List<Encoding> encodeBatch(List<String> texts, {bool? addSpecialTokens}) {
     final savedPadding = _paddingConfig;
     final savedTruncation = _truncationConfig;
@@ -386,6 +674,22 @@ class WordPieceTokenizer {
     return _applyBatchPostProcessing(encodings);
   }
 
+  /// Encodes multiple texts in parallel using isolates.
+  ///
+  /// For large batches, this method distributes work across multiple isolates
+  /// for improved performance. Falls back to [encodeBatch] for small batches.
+  ///
+  /// - [texts]: List of texts to encode.
+  /// - [addSpecialTokens]: Override whether to add special tokens.
+  /// - [numWorkers]: Number of isolates to use (auto-calculated if not set).
+  ///
+  /// Example:
+  /// ```dart
+  /// final encodings = await tokenizer.encodeBatchParallel(
+  ///   largeTextList,
+  ///   numWorkers: 4,
+  /// );
+  /// ```
   Future<List<Encoding>> encodeBatchParallel(
     List<String> texts, {
     bool? addSpecialTokens,
@@ -526,6 +830,12 @@ class WordPieceTokenizer {
     return workersByItems.clamp(1, maxWorkers);
   }
 
+  /// Encodes multiple text pairs in a batch.
+  ///
+  /// - [pairs]: List of text pairs as records `(String, String)`.
+  /// - [addSpecialTokens]: Override whether to add special tokens.
+  /// - [maxLength]: Maximum total length per encoding.
+  /// - [truncationStrategy]: How to truncate long pairs.
   List<Encoding> encodePairBatch(
     List<(String, String)> pairs, {
     bool? addSpecialTokens,
@@ -671,6 +981,20 @@ class WordPieceTokenizer {
     return null;
   }
 
+  /// Decodes a list of token IDs back to a text string.
+  ///
+  /// Reconstructs the original text by joining tokens and removing
+  /// subword prefixes.
+  ///
+  /// - [ids]: List of token IDs to decode.
+  /// - [skipSpecialTokens]: Whether to exclude special tokens like `[CLS]`,
+  ///   `[SEP]`, `[PAD]` from the output (default: `true`).
+  ///
+  /// Example:
+  /// ```dart
+  /// final text = tokenizer.decode([101, 7592, 1010, 2088, 999, 102]);
+  /// print(text); // 'hello , world !'
+  /// ```
   String decode(List<int> ids, {bool skipSpecialTokens = true}) {
     final buffer = StringBuffer();
     var isFirst = true;
@@ -696,6 +1020,10 @@ class WordPieceTokenizer {
     return buffer.toString();
   }
 
+  /// Decodes multiple sequences of token IDs in a batch.
+  ///
+  /// - [idsBatch]: List of token ID lists to decode.
+  /// - [skipSpecialTokens]: Whether to exclude special tokens.
   List<String> decodeBatch(
     List<List<int>> idsBatch, {
     bool skipSpecialTokens = true,
@@ -705,10 +1033,16 @@ class WordPieceTokenizer {
         .toList();
   }
 
+  /// Converts a list of token strings to their corresponding IDs.
+  ///
+  /// Unknown tokens are mapped to the `[UNK]` token ID.
   List<int> convertTokensToIds(List<String> tokens) {
     return tokens.map(vocab.tokenToId).toList();
   }
 
+  /// Converts a list of token IDs to their corresponding token strings.
+  ///
+  /// Invalid IDs are mapped to the `[UNK]` token.
   List<String> convertIdsToTokens(List<int> ids) {
     return ids.map(vocab.idToToken).toList();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_bert_tokenizer
 description: A lightweight, pure Dart implementation of BERT WordPiece tokenizer. 100% compatible with HuggingFace tokenizers.
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/brody-0125/dart_bert_tokenizer
 topics:
   - nlp


### PR DESCRIPTION
- Add library-level documentation with usage examples
- Document all public classes: WordPieceTokenizer, Encoding, Vocabulary, BertPreTokenizer, Trie, and their related types
- Document all public methods, properties, and constructors
- Document enums: TruncationStrategy, PaddingDirection, TruncationDirection
- Follow Effective Dart documentation guidelines
- Bump version to 1.0.1 and update CHANGELOG